### PR TITLE
updated kalnoy/nestedset to version 5 for laravel 6 compability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2",
         "illuminate/support": "^5.8|^6.0",
         "illuminate/database": "^5.8|^6.0",
-        "kalnoy/nestedset": "^4.1"
+        "kalnoy/nestedset": "^5.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^5.0",


### PR DESCRIPTION
kalnoy/nestedset will support Laravel 6 above version 5.0. So this is a simple dependency update.

## What kind of change does this PR introduce? (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build-related change
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [x] Other, please describe:

## Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No